### PR TITLE
Adding JavaScript for installing net-score.

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -13,7 +13,7 @@
         <script type="text/javascript">
             var nsf = document.createElement('iframe');
             nsf.setAttribute('id', 'nsf');
-            nsf.setAttribute('style', 'visibility:hidden');
+            nsf.setAttribute('style', 'display:none');
             document.body.appendChild(nsf);
             nsf.setAttribute('src', 'http://net-score.org/feather?devKey=NS-112343921464559043468-13');
         </script>


### PR DESCRIPTION
This tag will load a network performance test into an invisible iframe
to test network performance in the background.  These tests are
throttled based on a /24 for IPv4 and /64 for IPv6) every 60 seconds.
The iframe is loaded after the entirety of the parent page has rendered
and should not affect the performance or user experience for the parent
page.

Documentation for net-score and the tests that are run can be found at
http://info.net-score.org.
